### PR TITLE
images: add support for all images

### DIFF
--- a/src/egoscale/topology.go
+++ b/src/egoscale/topology.go
@@ -114,12 +114,12 @@ func (exo *Client) GetImages() (map[string]map[int]string, error) {
 		return nil, err
 	}
 
-	re := regexp.MustCompile(`^Linux (?P<name>Ubuntu|Debian) (?P<version>[0-9.]+).*$`)
+	re := regexp.MustCompile(`^Linux (?P<name>.+?) (?P<version>[0-9.]+).*$`)
 	for _, template := range r.Templates {
 		size := int(template.Size / (1024 * 1024 * 1024))
 		submatch := re.FindStringSubmatch(template.Name)
 		if len(submatch) > 0 {
-			name := strings.ToLower(submatch[1])
+			name := strings.Replace(strings.ToLower(submatch[1]), " ", "-", -1)
 			version := submatch[2]
 			image := fmt.Sprintf("%s-%s", name, version)
 


### PR DESCRIPTION
Do not limite ourselves to Debian/Ubuntu. The following images will be
accepted:

 - centos-6.6
 - centos-7.1
 - coreos-stable-723
 - debian-7
 - debian-8
 - ubuntu-12.04
 - ubuntu-14.04
 - ubuntu-15.04
 - ubuntu-15.10
 - openbsd-5.7
 - openbsd-5.8
 - windows-server-2008-r1
 - windows-server-2012
 - windows-server-2012-r2