### PR TITLE
Add Affinity Group support

### DIFF
--- a/src/egoscale/affinitygroup.go
+++ b/src/egoscale/affinitygroup.go
@@ -1,0 +1,42 @@
+package egoscale
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+func (exo *Client) CreateAffinityGroup(name string) (string, error) {
+	params := url.Values{}
+	params.Set("name", name)
+	params.Set("type", "host anti-affinity")
+
+	resp, err := exo.Request("createAffinityGroup", params)
+	if err != nil {
+		return "", err
+	}
+
+	var r CreateAffinityGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return "", err
+	}
+
+	return r.JobId, nil
+}
+
+func (exo *Client) DeleteAffinityGroup(name string) (string, error) {
+	params := url.Values{}
+	params.Set("name", name)
+
+	resp, err := exo.Request("deleteAffinityGroup", params)
+	if err != nil {
+		return "", err
+	}
+
+	var r DeleteAffinityGroupResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return "", err
+	}
+
+	return r.JobId, nil
+
+}

--- a/src/egoscale/async.go
+++ b/src/egoscale/async.go
@@ -34,3 +34,4 @@ func (exo *Client) AsyncToVirtualMachine(resp QueryAsyncJobResultResponse) (*Dep
 
 	return &r.Wrapped, nil
 }
+

--- a/src/egoscale/topology.go
+++ b/src/egoscale/topology.go
@@ -96,6 +96,29 @@ func (exo *Client) GetKeypairs() ([]string, error) {
 	return keypairs, nil
 }
 
+func (exo *Client) GetAffinityGroups() (map[string]string, error) {
+	var affinitygroups map[string]string
+	params := url.Values{}
+
+	resp, err := exo.Request("listAffinityGroups", params)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAffinityGroupsResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	affinitygroups = make(map[string]string)
+	for _, affinitygroup := range r.AffinityGroups {
+		affinitygroups[affinitygroup.Name] = affinitygroup.Id
+	}
+	return affinitygroups, nil
+
+}
+
 func (exo *Client) GetImages() (map[string]map[int]string, error) {
 	var images map[string]map[int]string
 	images = make(map[string]map[int]string)
@@ -153,6 +176,10 @@ func (exo *Client) GetTopology() (*Topology, error) {
 	if err != nil {
 		return nil, err
 	}
+	affinitygroups, err := exo.GetAffinityGroups()
+	if err != nil {
+		return nil, err
+	}
 	profiles, err := exo.GetProfiles()
 	if err != nil {
 		return nil, err
@@ -163,6 +190,7 @@ func (exo *Client) GetTopology() (*Topology, error) {
 		Profiles:       profiles,
 		Images:         images,
 		Keypairs:       keypairs,
+		AffinityGroups: affinitygroups,
 		SecurityGroups: groups,
 	}
 

--- a/src/egoscale/types.go
+++ b/src/egoscale/types.go
@@ -29,6 +29,7 @@ type Topology struct {
 	Profiles       map[string]string
 	Keypairs       []string
 	SecurityGroups map[string]string
+	AffinityGroups map[string]string
 }
 
 type SecurityGroupRule struct {
@@ -48,6 +49,7 @@ type MachineProfile struct {
 	ServiceOffering string
 	Template        string
 	Zone            string
+	AffinityGroups  []string
 }
 
 type ListZonesResponse struct {
@@ -147,6 +149,21 @@ type ListSSHKeyPairsResponse struct {
 type SSHKeyPair struct {
 	Fingerprint string `json:"fingerprint,omitempty"`
 	Name        string `json:"name,omitempty"`
+}
+
+type ListAffinityGroupsResponse struct {
+	 Count      	int 				`json:"count"`
+	 AffinityGroups []*AffinityGroup 	`json:"affinitygroup"`
+}
+
+type AffinityGroup struct {
+	Name 		string `json:"name,omitempty"`
+	Type 		string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+	Id   		string `json:"id,omitempty"`
+	Domainid 	string `json:"domainid,omitempty"`
+	Domain 		string `json:"domain,omitempty"`
+	Account 	string `json:"account,omitempty"`
 }
 
 type ListSecurityGroupsResponse struct {
@@ -400,6 +417,14 @@ type CreateSSHKeyPairWrappedResponse struct {
 
 type CreateSSHKeyPairResponse struct {
 	Privatekey string `json:"privatekey,omitempty"`
+}
+
+type CreateAffinityGroupResponse struct {
+	JobId string `json:"jobid,omitempty"`
+}
+
+type DeleteAffinityGroupResponse struct {
+	JobId string `json:"jobid,omitempty"`
 }
 
 type DeleteSSHKeyPairResponse struct {

--- a/src/egoscale/vm.go
+++ b/src/egoscale/vm.go
@@ -22,6 +22,9 @@ func (exo *Client) CreateVirtualMachine(p MachineProfile) (string, error) {
 	if len(p.Keypair) > 0 {
 		params.Set("keypair", p.Keypair)
 	}
+	if len(p.AffinityGroups) > 0 {
+		params.Set("affinitygroupnames", strings.Join(p.AffinityGroups, ","))
+	}
 
 	params.Set("securitygroupids", strings.Join(p.SecurityGroups, ","))
 


### PR DESCRIPTION
* This creates several types to define Affinity Groups (AF).
* It modifies the Topology and Machine Profile types to add AF.
* It adds an `affinitygroup.go` file for create and delete of AF.
* This modifies `vm.go` to set the AF on VM creation.

Note that if no AF are defined in the profile the VM creation will work.
You can pass multiple AF in the profile.

The example `exo.go` has also been modified to start the VM in a default _egoscale_ AF. Which is created if it does not exist.