### PR TITLE
Template: pick up on featured templates

### DIFF
--- a/src/egoscale/topology.go
+++ b/src/egoscale/topology.go
@@ -142,7 +142,7 @@ func (exo *Client) GetImages() (map[string]map[int]string, error) {
 	images = make(map[string]map[int]string)
 
 	params := url.Values{}
-	params.Set("templatefilter", "executable")
+	params.Set("templatefilter", "featured")
 
 	resp, err := exo.Request("listTemplates", params)
 


### PR DESCRIPTION
If another filter value is used to fetch the template list, more than 1
template will match the parameter, resulting in a random version of a
template being picked up. This result currently in breaking docker
deployment randomly for our customers.